### PR TITLE
Fix for bug that removes decimal separator in decimal values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
 
-    version='0.2.0',
+    version='0.2.1',
 
 #   scripts=[
 #       'bin/fundamentus.csv.py',

--- a/src/fundamentus/utils.py
+++ b/src/fundamentus/utils.py
@@ -3,7 +3,7 @@
 utils:
     Utility helpers.
 """
-
+import numpy
 import requests
 import requests_cache
 import pandas   as pd
@@ -76,7 +76,8 @@ def fmt_dec(val):
     """
 
     res = val
-    res = res.replace( to_replace=r'[.]', value='' , regex=True )
+
+    res = res.apply(lambda value: value.replace('.', '') if value is not numpy.NAN and '%' in value else value)
     res = res.replace( to_replace=r'[,]', value='.', regex=True )
 #   res = res.astype(float)
 #   res = res.astype(float) / 100

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,12 +46,12 @@ def test_from_pt_br_02():
 
 ###
 def test_fmt_dec():
-    more_data = { 'col1': [ 11,21],
-                  'col2': [ 12,22],
-                  'col3': [ 13,23]}
-    b = { 'data': [ '45,56%','1.045,56%' ]}
+    more_data = { 'col1': [ 11,21,31],
+                  'col2': [ 12,22,32],
+                  'col3': [ 13,23,33]}
+    b = { 'data': [ '45,56%','1.045,56%', '0.14' ]}
     b.update(more_data)
-    a = { 'data': [ '45.56%','1045.56%'  ]}
+    a = { 'data': [ '45.56%','1045.56%', '0.14' ]}
     a.update(more_data)
 
     _before = pd.DataFrame(b)


### PR DESCRIPTION
This Pull Request resolves the bug that removed the "." (decimal separator) character from decimal values, causing issues in the representation of fractional numbers. Due to this bug, values like 0.14 were incorrectly transformed into 014, leading to potential errors in calculations and numerical data visualization.

Changes made:

1. Identification and correction of the code snippet responsible for the bug, ensuring that the decimal separator is preserved when handling decimal values.
2. Updated `test_fmt_dec` unit tests for this fix.

I believe this fix will bring greater reliability and accuracy to the project, preventing errors related to the handling of decimal values.