### PR TITLE
Pandas 2.0 - remove append

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 requests>=2.25.1,<3.0
 requests-cache>=0.5.2,<1.0
 
-pandas>=1.2.0,<2.0
+pandas>=2.0.0
 lxml>=4.6.2,<5.0
 
 tabulate>=0.8.7,<=1.0

--- a/src/fundamentus/detalhes.py
+++ b/src/fundamentus/detalhes.py
@@ -56,12 +56,15 @@ def get_detalhes_list(lst):
     """
 
     result = pd.DataFrame()
-
+    list_dfs = [] # Empty list
     # build result for each get
     for papel in lst:
         logging.info('get list: [Papel: {}]'.format(papel))
         df = get_detalhes_papel(papel)
-        result = result.append(df)
+        list_dfs.append(df) # Add dataframes to list
+    
+    # Concat all dfs
+    result = pd.concat(list_dfs, ignore_index=False)
 
     # duplicate column (papel is the index already)
     try:


### PR DESCRIPTION
Olá!
Inicialmente parabéns pelo pacote!!

Criei esse PR pois o pandas 2.0 não possibilita mais o uso de append.
Ajustei a única função que utilizava o _append_ e substitui pelo _concat_.

Peço que avaliem se a contribuição possibilita ajustar as dependências, atualizando o projeto, permitindo usar com pandas 2.0.0...
Rodando as funções "local" deu tudo certo.
PS: Não consegui rodar os testes.

Att.,