### PR TITLE
fix: remove FutureWarning from read_html

### DIFF
--- a/src/fundamentus/detalhes.py
+++ b/src/fundamentus/detalhes.py
@@ -4,6 +4,7 @@ detalhes:
     Info from .../detalhes.php?papel=
 """
 
+from io import StringIO
 from . import utils
 
 # import fundamentus.utils as utils
@@ -229,7 +230,7 @@ def get_detalhes_raw(papel='WEGE3'):
             time.sleep(.500) # 500 ms
 
     ## parse
-    tables_html = pd.read_html(content.text, decimal=",", thousands='.')
+    tables_html = pd.read_html(StringIO(content.text), decimal=",", thousands='.')
 
     return tables_html
 
@@ -261,7 +262,7 @@ def list_papel_all():
             time.sleep(.500) # 500 ms
 
     ## parse
-    df = pd.read_html(content.text, decimal=",", thousands='.')[0]
+    df = pd.read_html(StringIO(content.text), decimal=",", thousands='.')[0]
 
     lst = list(df['Papel'])
     logging.info('members in list = {}'.format(len(lst)))

--- a/src/fundamentus/papel.py
+++ b/src/fundamentus/papel.py
@@ -4,6 +4,7 @@ papel:
     Info from .../detalhes.php, i.e., with no parameters
 """
 
+from io import StringIO
 import requests
 import requests_cache
 import pandas   as pd
@@ -51,7 +52,7 @@ def get_df_papel():
 
 
     ## parse
-    df = pd.read_html(content.text)[0]
+    df = pd.read_html(StringIO(content.text))[0]
 
     return df
 

--- a/src/fundamentus/resultado.py
+++ b/src/fundamentus/resultado.py
@@ -4,6 +4,7 @@ resultado:
 """
 
 
+from io import StringIO
 import fundamentus.utils as utils
 
 import requests
@@ -47,7 +48,7 @@ def get_resultado_raw():
 
 
     ## parse + load
-    df = pd.read_html(content.text, decimal=",", thousands='.')[0]
+    df = pd.read_html(StringIO(content.text), decimal=",", thousands='.')[0]
 
     ## Fix: percent string
     df['Div.Yield']     = utils.perc_to_float( df['Div.Yield']     )

--- a/src/fundamentus/setor.py
+++ b/src/fundamentus/setor.py
@@ -4,6 +4,7 @@ setor:
     Info from .../detalhes.php?setor=
 """
 
+from io import StringIO
 import requests
 import requests_cache
 import pandas   as pd
@@ -39,7 +40,7 @@ def list_papel_setor(setor=None):
 
 
     ## parse + load
-    df = pd.read_html(content.text, decimal=",", thousands='.')[0]
+    df = pd.read_html(StringIO(content.text), decimal=",", thousands='.')[0]
 
     ##
     return list(df['Papel'])


### PR DESCRIPTION
## Fix FutureWarning in read_html call

This pull request addresses a FutureWarning encountered in the codebase due to deprecated usage of literal HTML in the read_html function.

### Changes Made:

- Removed the FutureWarning caused by passing literal HTML to read_html.
- Replaced the deprecated usage with StringIO for improved compatibility.

### Files Modified:

- detalhes.py
- papel.py
- resultado.py
- setor.py

### Additional Information:

The deprecated usage of literal HTML in the read_html function was causing a FutureWarning in the codebase. This pull request resolves the warning by replacing the deprecated usage with StringIO, ensuring compatibility with future versions of the library.


This screenshot illustrates the FutureWarning encountered before the fix.
![FutureWarning](https://github.com/mv/fundamentus-api/assets/31565700/e136ee2b-e1c6-4ccc-bc03-e7d0d682c440)

This screenshot showcases the implementation of the fix using StringIO.
![fix-fururewarning](https://github.com/mv/fundamentus-api/assets/31565700/32d41e7c-f3b6-4892-874f-521d804a7f89)

