### PR TITLE
fix: Pandas error breaking the details examples and the det.py test

### DIFF
--- a/src/fundamentus/detalhes.py
+++ b/src/fundamentus/detalhes.py
@@ -61,7 +61,7 @@ def get_detalhes_list(lst):
     for papel in lst:
         logging.info('get list: [Papel: {}]'.format(papel))
         df = get_detalhes_papel(papel)
-        result = result.append(df)
+        result = pd.concat([result, df])
 
     # duplicate column (papel is the index already)
     try:

--- a/tests/det.py
+++ b/tests/det.py
@@ -21,8 +21,8 @@ detalhes.get_detalhes_papel('ITSA4')
 detalhes.get_detalhes_papel('WEGE3')
 detalhes.get_detalhes_list(['ITSA4','WEGE3'])
 
-detalhes.get_detalhes('ITSA4')
-detalhes.get_detalhes('WEGE3')
-detalhes.get_detalhes(['ITSA4','WEGE3'])
+detalhes.get_detalhes_raw('ITSA4')
+detalhes.get_detalhes_raw('WEGE3')
+detalhes.get_detalhes_list(['ITSA4','WEGE3'])
 
 


### PR DESCRIPTION
## Fix Examples Breaking Due to Changes in detalhes.py
This pull request addresses issues where examples using detalhes.py were breaking due to the way pandas' append method was used, and also corrects an error in the det.py test.

### Changes Made:
- Updated detalhes.py to resolve issues causing the examples to break.
- Corrected an error in the det.py test.
- Modified relevant examples to ensure compatibility with the updated detalhes.py file.

### Context:
In pandas versions > 2.0, the append method behavior has been updated, leading to failures in tests relying on the previous behavior. This pull request addresses these failures by updating the append method usage in relevant files.

This screenshot illustrates the error encountered before the fix.
![error_append_pandas](https://github.com/mv/fundamentus-api/assets/31565700/0342283a-0d6f-4959-9368-0bb00ccecb43)


This screenshot showcases the implementation of the fix the concat form.
![fix_append_pandas](https://github.com/mv/fundamentus-api/assets/31565700/3c961d9d-47f9-4894-b1ff-a72382fa0ee6)



